### PR TITLE
updating to function runtime 3.0 and .netcore 3.1. writing to local t…

### DIFF
--- a/Encoding/Encoding/Encoding.csproj
+++ b/Encoding/Encoding/Encoding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <Version>1.0.0</Version>
    </PropertyGroup>
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.2" />
     <PackageReference Include="Microsoft.Azure.Management.Media" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.3.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Encoding/Encoding/VodFunctions/ffmpeg-encoding.cs
+++ b/Encoding/Encoding/VodFunctions/ffmpeg-encoding.cs
@@ -81,12 +81,13 @@ namespace Encoding
             try
             {
                 var folder = context.FunctionDirectory;
+                var tempFolder = Path.GetTempPath();
 
                 string inputFileName = System.IO.Path.GetFileName(new Uri(sasInputUrl).LocalPath);
-                string pathLocalInput = System.IO.Path.Combine(context.FunctionDirectory, inputFileName);
+                string pathLocalInput = System.IO.Path.Combine(tempFolder, inputFileName);
 
                 string outputFileName = System.IO.Path.GetFileName(new Uri(sasOutputUrl).LocalPath);
-                string pathLocalOutput = System.IO.Path.Combine(context.FunctionDirectory, outputFileName);
+                string pathLocalOutput = System.IO.Path.Combine(tempFolder, outputFileName);
 
                 foreach (DriveInfo drive in DriveInfo.GetDrives().Where(d => d.IsReady))
                 {


### PR DESCRIPTION
This PR addresses #7 
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Updates ffmpeg function to use function runtime 3.0 and .netcore 3.1.
* Functions runtime 3.0 prevents function from writing to FunctionsDirectory, so updating to temp storage.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
Updates function to latest tools/sdks/runtimes.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->