### PR TITLE
adding escape for single quote in parameters

### DIFF
--- a/Encoding/Encoding/VodFunctions/ffmpeg-encoding.cs
+++ b/Encoding/Encoding/VodFunctions/ffmpeg-encoding.cs
@@ -118,8 +118,8 @@ namespace Encoding
 
                 process.StartInfo.Arguments = (ffmpegArguments ?? " -i {input} {output} -y")
                     .Replace("{input}", "\"" + pathLocalInput + "\"")
-                    .Replace("{output}", "\"" + pathLocalOutput + "\"");
-
+                    .Replace("{output}", "\"" + pathLocalOutput + "\"")
+                    .Replace("'", "\"");
 
                 log.LogInformation(process.StartInfo.Arguments);
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes #8 - escapes single quote in parameters with a double quote.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
* Run the function with the following example payload:
`{
    "sasInputUrl":"",
    "sasOutputUrl":"",
    "ffmpegArguments" :  -i {input} -ac 1 -filter_complex:a '[0:a]aresample=8000,asplit[0]' -map '[0]' -c:a pcm_s16le -f data {output} 
}
`
The single quotes will be replaced with double quotes and ffmpeg will be able to run the command without an invalid parameter error.

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->